### PR TITLE
docker image github workflow

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,65 @@
+name: Docker Image Latest
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ "main", "master" ]
+  pull_request:
+    branches: [ "main", "master" ]
+
+env:
+  REGISTRY: ghcr.io
+
+
+jobs:
+
+  build-and-publish-latest:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Generate Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+#            docker.io/${{ github.repository }}
+          images: |
+            ghcr.io/${{ github.repository }}
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+          flavor: |
+            latest=true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+#      - name: Login to DockerHub
+#        uses: docker/login-action@v1
+#        with:
+#          username: ${{ github.repository_owner }}
+#          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        env:
+          DOCKER_BUILDKIT: 1
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -48,11 +48,6 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-#      - name: Login to DockerHub
-#        uses: docker/login-action@v1
-#        with:
-#          username: ${{ github.repository_owner }}
-#          password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Build and push
         uses: docker/build-push-action@v5

--- a/README.md
+++ b/README.md
@@ -22,9 +22,10 @@ By default temperature, humidity, CO2 and the battery state of the sensor are be
 
 If you need any other data which also gets parsed and published by this piece of software, you can use the MQTT Integration in Home Assistant for that.
 
-## Docker deployment
+## Docker deployment options
 
-Just run the provided docker compose file
+- Run the provided docker compose file
+- docker pull ghcr.io/niklasarnitz/pr_qingping-co2-temp-rh-sensor-mqtt-parser:latest
 
 ## Development
 


### PR DESCRIPTION
An already working job to automatically create a docker image on GitHub Packages.
You don't need to fill any secret tokens or pay for the disk space. The token is automatically securely passed by GitHub Action, and the space is free as long as the project is public.

Successful job result: https://github.com/ALERTua/pr_qingping-co2-temp-rh-sensor-mqtt-parser/actions/runs/7488178001/job/20382086987